### PR TITLE
fix long text editor timer bug

### DIFF
--- a/src/SimpleLongTextFormatter/index.js
+++ b/src/SimpleLongTextFormatter/index.js
@@ -26,6 +26,10 @@ class SimpleLongTextFormatter extends React.Component {
     };
   }
 
+  componentWillUnmount() {
+    this.clearTimer();
+  }
+
   renderLinks = (value) => {
     const links = value.links;
     if (!Array.isArray(links) || links.length === 0) return null;


### PR DESCRIPTION
长文本组件卸载前，如果有定时器，应该清空定时器，否则可能报错