### PR TITLE
Change date and collaborator editor

### DIFF
--- a/src/CollaboratorEditor/index.css
+++ b/src/CollaboratorEditor/index.css
@@ -14,8 +14,12 @@
   min-height: 160px;
   max-height: 200px;
   margin: 10px 0;
-  padding: 0 10px;
   overflow: auto;
+}
+
+.dtable-ui-collaborator-editor-popover .collaborator-list-container .search-option-null {
+  opacity: 0.5;
+  padding-left: 10px;
 }
 
 .dtable-ui-collaborator-editor-popover .collaborator-list-container .collaborator-item-container {
@@ -23,7 +27,7 @@
   align-items: center;
   justify-content: space-between;
   height: 30px;
-  padding-left: 12px;
+  padding: 0 10px;
   font-size: 14px;
   cursor: pointer;
 }
@@ -44,4 +48,23 @@
 .dtable-ui-collaborator-editor-popover .collaborator-checked .dtable-font {
   font-size: 12px;
   color: #798d99;
+}
+
+.dtable-ui-collaborator-editor .dtable-ui-collaborator-editor-container-no-btn {
+  min-height: 40px;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid rgba(0, 40, 100, 0.12);
+  border-radius: 3px;
+  transition: border-color .15s ease-in-out;
+}
+
+.dtable-ui-collaborator-editor .dtable-ui-collaborator-editor-container-no-btn .collaborators-container {
+  min-height: 26px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dtable-ui-collaborator-editor .dtable-ui-collaborator-editor-container-no-btn .collaborators-container .collaborator-item {
+  margin: 2px 10px 2px 0;
 }

--- a/src/CollaboratorEditor/index.js
+++ b/src/CollaboratorEditor/index.js
@@ -15,11 +15,13 @@ const propTypes = {
   column: PropTypes.object,
   collaborators: PropTypes.array.isRequired,
   onCommit: PropTypes.func,
+  isShowEditButton: PropTypes.bool,
 };
 
 class CollaboratorEditor extends React.Component {
 
   static defaultProps = {
+    isShowEditButton: true,
     isReadOnly: false,
     value: [],
   }
@@ -34,14 +36,14 @@ class CollaboratorEditor extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onDocumentToggle);
+    document.addEventListener('mousedown', this.onMouseDown);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.onDocumentToggle);
+    document.removeEventListener('mousedown', this.onMouseDown);
   }
 
-  onDocumentToggle = (e) => {
+  onMouseDown = (e) => {
     if (this.editorContainer !== e.target && !this.editorContainer.contains(e.target)) {
       this.onClosePopover();
     }
@@ -58,7 +60,7 @@ class CollaboratorEditor extends React.Component {
     return [];
   }
 
-  onAddOptionToggle = (event) => {
+  togglePopover = (event) => {
     event.nativeEvent.stopImmediatePropagation();
     event.stopPropagation();
     if (this.props.isReadOnly) {
@@ -91,7 +93,6 @@ class CollaboratorEditor extends React.Component {
 
     this.setState({newValue}, () => {
       this.onCommit(newValue);
-      this.onClosePopover();
     });
   }
 
@@ -123,6 +124,16 @@ class CollaboratorEditor extends React.Component {
     this.setState({isPopoverShow: false});
   }
 
+  onClickContainer = (e) => {
+    e.stopPropagation();
+    if (!this.props.isShowEditButton && !this.state.isPopoverShow) {
+      this.setState({
+        isPopoverShow: true,
+        popoverPosition: this.caculatePopoverPosition(),
+      });
+    }
+  }
+
   setEditorContainerRef = (editorContainer) => {
     this.editorContainer = editorContainer;
   }
@@ -132,17 +143,19 @@ class CollaboratorEditor extends React.Component {
   }
 
   render() {
-    let { collaborators, isReadOnly } = this.props;
+    let { collaborators, isReadOnly, isShowEditButton } = this.props;
     let { isPopoverShow, popoverPosition } = this.state;
     let selectedCollaborators = this.getFormattedCollaborators();
     let enableDeleteCollaborator = !isReadOnly;
 
     return (
       <div ref={this.setEditorContainerRef} className="dtable-ui-collaborator-editor">
-        <div ref={this.setEditorRef} className="dtable-ui-collaborator-editor-container">
-          <EditEditorButton text={getLocale('Add_a_collaborator')} onClick={this.onAddOptionToggle} />
+        <div ref={this.setEditorRef} className={`dtable-ui-collaborator-editor-container ${isShowEditButton ? '' : 'dtable-ui-collaborator-editor-container-no-btn'}`} onClick={this.onClickContainer}>
+          {isShowEditButton &&
+            <EditEditorButton text={getLocale('Add_a_collaborator')} onClick={this.togglePopover} />
+          }
           {selectedCollaborators.length > 0 && (
-            <div className="collaborators-container mt-2">
+            <div className={`collaborators-container ${isShowEditButton ? 'mt-2' : ''}`}>
               {selectedCollaborators.map(collaborator => {
                 return (
                   <CollaboratorItem

--- a/src/DateEditor/index.js
+++ b/src/DateEditor/index.js
@@ -6,6 +6,9 @@ import { getDateDisplayString }  from 'dtable-utils';
 import PCDateEditorPopover from './pc-date-editor-popover';
 import MBDateEditorPopover from './mb-date-editor-popover';
 
+import 'dayjs/locale/zh-cn';
+import 'dayjs/locale/en-gb';
+
 import './index.css';
 
 const propTypes = {

--- a/src/LinkEditor/index.js
+++ b/src/LinkEditor/index.js
@@ -49,14 +49,14 @@ class LinkEditor extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onDocumentToggle);
+    document.addEventListener('mousedown', this.onMouseDown);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.onDocumentToggle);
+    document.removeEventListener('mousedown', this.onMouseDown);
   }
 
-  onDocumentToggle = (e) => {
+  onMouseDown = (e) => {
     if (this.editorContainer !== e.target && !this.editorContainer.contains(e.target)) {
       this.onClosePopover();
     }

--- a/src/MultipleSelectEditor/index.js
+++ b/src/MultipleSelectEditor/index.js
@@ -36,14 +36,14 @@ class MultipleSelectEditor extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onDocumentToggle);
+    document.addEventListener('mousedown', this.onMouseDown);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.onDocumentToggle);
+    document.removeEventListener('mousedown', this.onMouseDown);
   }
 
-  onDocumentToggle = (e) => {
+  onMouseDown = (e) => {
     if (this.editorContainer !== e.target && !this.editorContainer.contains(e.target)) {
       this.onClosePopover();
     }

--- a/src/NotificationPopover/index.js
+++ b/src/NotificationPopover/index.js
@@ -25,16 +25,16 @@ export default class NotificationPopover extends React.Component {
   };
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.handleOutsideClick);
+    document.addEventListener('mousedown', this.onMouseDown);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleOutsideClick);
+    document.removeEventListener('mousedown', this.onMouseDown);
   }
 
-  handleOutsideClick = (e) => {
+  onMouseDown = (e) => {
     if (!this.notificationContainerRef.contains(e.target)) {
-      document.removeEventListener('mousedown', this.handleOutsideClick);
+      document.removeEventListener('mousedown', this.onMouseDown);
       if (e.target.className === 'tool notification' || e.target.parentNode.className === 'tool notification') {
         return;
       }

--- a/src/SingleSelectEditor/index.js
+++ b/src/SingleSelectEditor/index.js
@@ -36,14 +36,14 @@ class SingleSelectEditor extends React.Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onDocumentToggle);
+    document.addEventListener('mousedown', this.onMouseDown);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.onDocumentToggle);
+    document.removeEventListener('mousedown', this.onMouseDown);
   }
 
-  onDocumentToggle = (e) => {
+  onMouseDown = (e) => {
     if (this.editorContainer !== e.target && !this.editorContainer.contains(e.target)) {
       this.onClosePopover();
     }

--- a/src/common/ClickOutside.js
+++ b/src/common/ClickOutside.js
@@ -5,7 +5,7 @@ export default class ClickOutside extends React.Component {
 
   static propTypes = {
     children: PropTypes.element.isRequired,
-    onClickOutside: PropTypes.func.isRequired
+    onClickOutside: PropTypes.func,
   };
 
   isClickedInside = false;
@@ -24,7 +24,7 @@ export default class ClickOutside extends React.Component {
       return;
     }
 
-    this.props.onClickOutside(e);
+    this.props.onClickOutside && this.props.onClickOutside(e);
   };
 
   handleMouseDown = () => {

--- a/src/common/delete-tip.js
+++ b/src/common/delete-tip.js
@@ -15,14 +15,14 @@ export default class DeleteTip extends React.Component {
   };
 
   componentDidMount() {
-    document.addEventListener('click', this.handleOutsideClick);
+    document.addEventListener('mousedown', this.onMouseDown);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.handleOutsideClick);
+    document.removeEventListener('mousedown', this.onMouseDown);
   }
 
-  handleOutsideClick = (e) => {
+  onMouseDown = (e) => {
     if (this.tipContainer && !this.tipContainer.contains(e.target)) {
       this.props.toggle();
     }


### PR DESCRIPTION
1、更新 react 版本到 17 后，需要处理 onClick 事件，改成 onMouseDown 事件。
2、协作人编辑器样式比较早，鼠标经过的阴影不是通栏的，需要改成通栏；原来始终显示 Add collaborator 按钮，这个改成传参显示等。
3、日历编辑器中应该完善翻译（dayjs 处理中英文翻译）