### PR TITLE
fix(GeolocationEditor): handle missing geo-data files gracefully

### DIFF
--- a/src/GeolocationEditor/index.js
+++ b/src/GeolocationEditor/index.js
@@ -9,38 +9,38 @@ const GeolocationEditor = forwardRef(({ isMobile, config: propsConfig, ...props 
   const config = useMemo(() => ({ ...window?.dtable, ...propsConfig, }), [propsConfig]);
 
   const getLocationData = useCallback(() => {
-    if (window?.app?.location) return new Promise((resolve, reject) => {
+    if (window?.app?.location) return new Promise((resolve) => {
       resolve(window.app.location);
     });
     const { server = '', mediaUrl = '' } = config || {};
     return fetch(`${server}${mediaUrl}geo-data/cn-location.json`.replaceAll('//', '/')).then((res) => { // get locations from server
       return res.json();
     }).catch(() => {
-      // get locations from local
+      // get locations from local, fall back to empty object if unavailable
       return fetch('./geo-data/cn-location.json').then(res => {
         return res.json();
-      });
+      }).catch(() => null);
     });
   }, [config]);
 
   const getCountryData = useCallback((lang) => {
-    if (lang === 'cn' && window.app.countryListCn) return new Promise((resolve, reject) => {
+    if (lang === 'cn' && window.app.countryListCn) return new Promise((resolve) => {
       resolve(window.app.countryListCn);
     });
-    if (lang !== 'cn' && window.app.countryListEn) return new Promise((resolve, reject) => {
+    if (lang !== 'cn' && window.app.countryListEn) return new Promise((resolve) => {
       resolve(window.app.countryListEn);
     });
 
-    const { mediaUrl = '', server = '' } = config;
+    const { mediaUrl = '', server = '' } = config || {};
     const geoFileName = lang === 'cn' ? 'cn-region-location' : 'en-region-location';
     return fetch(`${server}${mediaUrl}geo-data/${geoFileName}.json`.replaceAll('//', '/'))
       .then(res => {
         return res.json();
       }).catch(() => {
-        // get locations from local
+        // get locations from local, fall back to null if unavailable
         return fetch(`./geo-data/${geoFileName}.json`).then(res => {
           return res.json();
-        });
+        }).catch(() => null);
       }).then(res => {
         const data = res || {};
         if (lang === 'cn') {

--- a/src/GeolocationEditor/mb-editor/country-editor.js
+++ b/src/GeolocationEditor/mb-editor/country-editor.js
@@ -21,10 +21,13 @@ const CountryEditor = ({
 
   useEffect(() => {
     getData().then(data => {
-      locations.current = data;
-      const continent = data.find(a => a.children.find(b => b.value === oldValue?.country_region || ''));
+      const safeData = data || [];
+      locations.current = safeData;
+      const continent = safeData.find(a => a.children && a.children.find(b => b.value === oldValue?.country_region || ''));
       const value = [continent?.value || '', oldValue?.country_region || ''];
       setValue(value);
+      setLoading(false);
+    }).catch(() => {
       setLoading(false);
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/GeolocationEditor/mb-editor/index.js
+++ b/src/GeolocationEditor/mb-editor/index.js
@@ -11,6 +11,7 @@ import MapSelectionEditor from './map-selection-editor';
 import './index.css';
 
 const transLocationData = (data) => {
+  if (!data) return [];
   if (Object.prototype.toString.call(data) === '[object Object]') {
     const name = data.name;
     data.label = name;
@@ -22,10 +23,11 @@ const transLocationData = (data) => {
       });
     }
   }
-  return data.children;
+  return data.children || [];
 };
 
 const transCountryData = (data) => {
+  if (!data) return [];
   let _data = [];
   // eslint-disable-next-line
   for (let key in data) {

--- a/src/GeolocationEditor/mb-editor/location-editor.js
+++ b/src/GeolocationEditor/mb-editor/location-editor.js
@@ -28,7 +28,9 @@ const LocationEditor = ({
 
   useEffect(() => {
     getData().then(data => {
-      locations.current = data;
+      locations.current = data || [];
+      setLoading(false);
+    }).catch(() => {
       setLoading(false);
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/GeolocationEditor/mb-editor/province-city-editor.js
+++ b/src/GeolocationEditor/mb-editor/province-city-editor.js
@@ -21,7 +21,9 @@ const ProvinceCityEditor = ({
 
   useEffect(() => {
     getData().then(data => {
-      locations.current = data;
+      locations.current = data || [];
+      setLoading(false);
+    }).catch(() => {
       setLoading(false);
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/GeolocationEditor/mb-editor/province-editor.js
+++ b/src/GeolocationEditor/mb-editor/province-editor.js
@@ -21,7 +21,9 @@ const ProvinceEditor = ({
 
   useEffect(() => {
     getData().then(data => {
-      locations.current = data;
+      locations.current = data || [];
+      setLoading(false);
+    }).catch(() => {
       setLoading(false);
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/GeolocationEditor/pc-editor/location-editor.js
+++ b/src/GeolocationEditor/pc-editor/location-editor.js
@@ -44,7 +44,7 @@ class LocationEditor extends Component {
 
   UNSAFE_componentWillMount() {
     this.props.getData().then(data => {
-      this.locations = data;
+      this.locations = data || {};
       const { selectedProvince, selectedCity, selectedCounty, selectedItem } = this.initLocationSelecting(this.value);
       this.setState({
         isLoadingData: false,
@@ -53,28 +53,31 @@ class LocationEditor extends Component {
         selectedCounty,
         selectedItem
       });
+    }).catch(() => {
+      this.locations = {};
+      this.setState({ isLoadingData: false });
     });
   }
 
   initLocationSelecting = (value) => {
-    let selectedProvince = this.locations.children.find((province) => {
-      return value.province && value.province.length > 0 && province.name.includes(value.province);
+    let selectedProvince = (this.locations.children || []).find((province) => {
+      return value.province && value.province.length > 0 && province.name && province.name.includes(value.province);
     });
 
     if (!selectedProvince) {
       return { selectedProvince: null, selectedCity: null, selectedCounty: null, selectedItem: 'province' };
     }
 
-    let selectedCity = selectedProvince.children.find((city) => {
-      return value.city && value.city.length > 0 && city.name.includes(value.city);
+    let selectedCity = (selectedProvince.children || []).find((city) => {
+      return value.city && value.city.length > 0 && city.name && city.name.includes(value.city);
     });
 
     if (!selectedCity) {
       return { selectedProvince, selectedCity: null, selectedCounty: null, selectedItem: 'city' };
     }
 
-    let selectedCounty = selectedCity.children.find((county) => {
-      return value.district && value.district.length > 0 && county.name.includes(value.district);
+    let selectedCounty = (selectedCity.children || []).find((county) => {
+      return value.district && value.district.length > 0 && county.name && county.name.includes(value.district);
     });
 
     if (!selectedCounty) {

--- a/src/GeolocationEditor/pc-editor/province-city-editor.js
+++ b/src/GeolocationEditor/pc-editor/province-city-editor.js
@@ -41,7 +41,7 @@ class ProvinceCityEditor extends Component {
 
   componentDidMount() {
     this.props.getData().then(data => {
-      this.locations = data;
+      this.locations = data || {};
       const { selectedProvince, selectedCity, selectedItem } = this.initLocationSelecting(this.value);
       this.setState({
         isLoadingData: false,
@@ -49,20 +49,23 @@ class ProvinceCityEditor extends Component {
         selectedCity,
         selectedItem
       });
+    }).catch(() => {
+      this.locations = {};
+      this.setState({ isLoadingData: false });
     });
   }
 
   initLocationSelecting = (value) => {
-    let selectedProvince = this.locations.children.find((province) => {
-      return value.province && value.province.length > 0 && province.name.includes(value.province);
+    let selectedProvince = (this.locations.children || []).find((province) => {
+      return value.province && value.province.length > 0 && province.name && province.name.includes(value.province);
     });
 
     if (!selectedProvince) {
       return { selectedProvince: null, selectedCity: null, selectedItem: 'province' };
     }
 
-    let selectedCity = selectedProvince.children.find((city) => {
-      return value.city && value.city.length > 0 && city.name.includes(value.city);
+    let selectedCity = (selectedProvince.children || []).find((city) => {
+      return value.city && value.city.length > 0 && city.name && city.name.includes(value.city);
     });
 
     if (!selectedCity) {

--- a/src/GeolocationEditor/pc-editor/province-editor.js
+++ b/src/GeolocationEditor/pc-editor/province-editor.js
@@ -34,11 +34,15 @@ class ProvinceEditor extends Component {
 
   componentDidMount() {
     this.props.getData().then(data => {
-      this.locations = data;
-      this.filteredProvince = this.locations.children;
+      this.locations = data || {};
+      this.filteredProvince = this.locations.children || [];
       this.setState({
         isLoadingData: false,
       });
+    }).catch(() => {
+      this.locations = {};
+      this.filteredProvince = [];
+      this.setState({ isLoadingData: false });
     });
     document.addEventListener('keydown', this.onHotKey, true);
   }
@@ -120,7 +124,7 @@ class ProvinceEditor extends Component {
     if (value.length > 0) {
       this.provinceReg = new RegExp(value, 'i');
     }
-    this.filteredProvince = this.locations.children.filter((item) => {
+    this.filteredProvince = (this.locations.children || []).filter((item) => {
       if (!this.provinceReg) {
         return true;
       }


### PR DESCRIPTION
## Problem

In SeaTable external apps (Universal Apps), geo-data JSON files are fetched from a path derived from `mediaUrl`, which in the external app context resolves to the app's own URL (e.g. `/external-apps/<uuid>/geo-data/`). These files don't exist there, causing 404 errors.

**404s observed:**
- `/external-apps/<uuid>/geo-data/en-region-location.json` → 404
- `/external-apps/<uuid>/geo-data/cn-location.json` → 404
- `/external-apps/<uuid>/geo-data/cn-region-location.json` → 404

This produces **white screens** with:
```
TypeError: Cannot read properties of undefined (reading "includes")
  at Array.filter
  at DE.render
```

Closes #437

## Root Causes

1. **`getLocationData`/`getCountryData`**: The local fallback `fetch('./geo-data/...')` has no `.catch()`, so when both fetches fail the returned promise **rejects**. Component `.then()` handlers never run.

2. **`getCountryData`**: `const { mediaUrl = '', server = '' } = config;` throws if `config` is `null`/`undefined` (unlike `getLocationData` which already uses `config || {}`).

3. **PC editors** (`ProvinceEditor`, `ProvinceCityEditor`, `LocationEditor`): No `.catch()` on `getData()` call; `this.locations.children` accessed without null guard; `province.name.includes(...)` called without checking `province.name` is defined.

4. **MB editors**: Missing `.catch()` handlers and null guards in `transLocationData`/`transCountryData` and functional components.

## Fix

- Both fetch chains always resolve: fallback adds `.catch(() => null)` so the outer `.then(res => { const data = res || {}; })` always runs
- `config || {}` added to `getCountryData`
- All `getData().then(data => ...)` calls get `.catch(() => setLoadingFalse)` 
- `(this.locations.children || [])` and `province.name &&` guards added throughout
- `transLocationData(null)` returns `[]` instead of crashing on `.children`
