### PR TITLE
feat(geolocation): add district name compatibility mapping

### DIFF
--- a/src/GeolocationEditor/mb-editor/location-editor.js
+++ b/src/GeolocationEditor/mb-editor/location-editor.js
@@ -6,6 +6,7 @@ import List from '../../List';
 import MobileFullScreenPage from '../../MobileFullScreenPage';
 import { getLocale } from '../../lang';
 import ObjectUtils from '../../utils/object-utils';
+import { DISTRICT_COMPAT_MAP } from 'dtable-utils';
 
 const { Header, Body } = MobileFullScreenPage;
 
@@ -17,7 +18,11 @@ const LocationEditor = ({
   onToggle,
   onCommit,
 }) => {
-  let initValue = [oldValue?.province || '', oldValue?.city || '', oldValue?.district || ''];
+  let district = oldValue?.district || '';
+  if (DISTRICT_COMPAT_MAP[district]) {
+    district = DISTRICT_COMPAT_MAP[district];
+  }
+  let initValue = [oldValue?.province || '', oldValue?.city || '', district];
   if (isShowDetails) {
     initValue.push(oldValue?.detail || '');
   }
@@ -31,7 +36,7 @@ const LocationEditor = ({
       locations.current = data;
       setLoading(false);
     });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const onValueChange = useCallback((newValue) => {

--- a/src/GeolocationEditor/pc-editor/location-editor.js
+++ b/src/GeolocationEditor/pc-editor/location-editor.js
@@ -8,6 +8,7 @@ import { KeyCodes } from '../../constants';
 import Loading from '../../Loading';
 import parseGeolocation from './parse-geolocation';
 import { getLocale } from '../../lang';
+import { DISTRICT_COMPAT_MAP } from 'dtable-utils';
 
 const propTypes = {
   isShowDetails: PropTypes.bool,
@@ -26,7 +27,7 @@ class LocationEditor extends Component {
     this.locations = {};
     this.state = {
       isShowSelector: false,
-      location: `${this.value.province || ''}${this.value.city || ''}${this.value.district || ''}`,
+      location: `${this.value.province || ''}${this.value.city || ''}${DISTRICT_COMPAT_MAP[this.value.district] || this.value.district || ''}`,
       selectedProvince: null,
       selectedCity: null,
       selectedCounty: null,
@@ -73,8 +74,13 @@ class LocationEditor extends Component {
       return { selectedProvince, selectedCity: null, selectedCounty: null, selectedItem: 'city' };
     }
 
+    let districtName = value.district || '';
+    if (DISTRICT_COMPAT_MAP[districtName]) {
+      districtName = DISTRICT_COMPAT_MAP[districtName];
+    }
+
     let selectedCounty = selectedCity.children.find((county) => {
-      return value.district && value.district.length > 0 && county.name.includes(value.district);
+      return districtName && districtName.length > 0 && county.name.includes(districtName);
     });
 
     if (!selectedCounty) {
@@ -267,23 +273,23 @@ class LocationEditor extends Component {
               )}
             </div>
             {this.props.isShowDetails &&
-            <div className="dtable-ui-geolocation-editor-item dtable-ui-geolocation-editor-detail">
-              <div className="dtable-ui-geolocation-editor-item-left">
-                {getLocale('Detailed_address') + ':'}
+              <div className="dtable-ui-geolocation-editor-item dtable-ui-geolocation-editor-detail">
+                <div className="dtable-ui-geolocation-editor-item-left">
+                  {getLocale('Detailed_address') + ':'}
+                </div>
+                <div className="dtable-ui-geolocation-editor-item-right">
+                  <textarea
+                    ref={ref => (this.detailInfo = ref)}
+                    placeholder={getLocale('Detailed_address_placeholder')}
+                    className="dtable-ui-geolocation-editor-detail-info"
+                    type="text"
+                    onChange={this.onChange}
+                    defaultValue={this.value.detail}
+                    onKeyDown={this.onKeyDown}
+                    autoFocus
+                  />
+                </div>
               </div>
-              <div className="dtable-ui-geolocation-editor-item-right">
-                <textarea
-                  ref={ref => (this.detailInfo = ref)}
-                  placeholder={getLocale('Detailed_address_placeholder')}
-                  className="dtable-ui-geolocation-editor-detail-info"
-                  type="text"
-                  onChange={this.onChange}
-                  defaultValue={this.value.detail}
-                  onKeyDown={this.onKeyDown}
-                  autoFocus
-                />
-              </div>
-            </div>
             }
             <div className="dtable-ui-geolocation-editor-item dtable-ui-geolocation-editor-parse">
               <div className="dtable-ui-geolocation-editor-item-left">

--- a/src/GeolocationEditor/pc-editor/parse-geolocation.js
+++ b/src/GeolocationEditor/pc-editor/parse-geolocation.js
@@ -1,3 +1,5 @@
+import { DISTRICT_COMPAT_MAP } from 'dtable-utils';
+
 const MUNICIPALITY = ['北京市', '天津市', '上海市', '重庆市', '香港', '澳门'];
 
 let initProvince = null;
@@ -125,6 +127,22 @@ const getDistrict = (province, city, string, geoTree) => {
   if (!string) {
     return { province, city, district: '', detail: '' };
   }
+
+  // Compatibility fallback: when the remaining string starts with a legacy district name,
+  // and the current city has the mapped new district, return the new district node directly.
+  if (city && string && DISTRICT_COMPAT_MAP) {
+    // eslint-disable-next-line no-unused-vars
+    for (const [oldName, newName] of Object.entries(DISTRICT_COMPAT_MAP)) {
+      if (string.indexOf(oldName) === 0) {
+        const newDistrict = city.children.find(item => item.name === newName);
+        if (newDistrict) {
+          const remainingString = string.substring(oldName.length);
+          return { province, city, district: newDistrict, string: remainingString };
+        }
+      }
+    }
+  }
+
   let startPoint = 0;
   let endPoint = 2;
   let subDistrict = string.substring(startPoint, endPoint);
@@ -206,6 +224,11 @@ const parseGeolocationString = (geoTree, geoString) => {
   province = districtResult.province;
   city = districtResult.city;
   string = districtResult.string;
+
+  if (district && DISTRICT_COMPAT_MAP[district.name]) {
+    district = { ...district, name: DISTRICT_COMPAT_MAP[district.name] };
+  }
+
   return { province, city, district, detail: string };
 };
 


### PR DESCRIPTION
- Import and apply DISTRICT_COMPAT_MAP from dtable-utils to handle legacy district names
- Update location editor initialization to use mapped district names
- Add compatibility fallback in parseGeolocation for legacy district name parsing
- Fix indentation in detail address section